### PR TITLE
Small fixes

### DIFF
--- a/public/layouts/rpr_2column/recipe.php
+++ b/public/layouts/rpr_2column/recipe.php
@@ -9,7 +9,7 @@ Description: A basic layoutin two columns. This layout provides all the bits you
 */
 ?>
 
-<div class="<?php esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
+<div class="<?php echo sanitize_html_class( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
 <?php
 /** 
  * Displaying the recipe title is normally done by the theme as post_title().

--- a/public/layouts/rpr_default/recipe.php
+++ b/public/layouts/rpr_default/recipe.php
@@ -8,7 +8,7 @@ Version: 0.2
 Description: The default layout. Despite being default this layout provides all the bits you need to display proper recipes. Structured meta data for search engine come standard. </br> Use the options below to finetune the look and feel of your recipes.
 */
 ?>
-<div class="<?php esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
+<div class="<?php echo sanitize_html_class( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
 <?php
 /** 
  * Displaying the recipe title is normally done by the theme as post_title().

--- a/public/rpr_template_tags.php
+++ b/public/rpr_template_tags.php
@@ -358,8 +358,8 @@ if( !function_exists( 'get_the_rpr_structured_data_header' ) ){
 			$out .= '<div vocab="http://schema.org/" typeof="Recipe">';
 			$out .= '<span class="rpr_title hidden" property="name">' . get_the_title( $recipe_id ) . '</span>';
 			$out .= '<span class="rpr_author hidden" property="author">' . get_the_author() . '</span>';
-			$out .= '<meta class="rpr_date hidden" property="datePublished" content="' . get_the_time( 'Y-m-d' ) . '">' . 
-				get_the_time( get_option('date_format') ) . '</meta>';
+			$out .= '<span class="rpr_date hidden" property="datePublished" content="' . get_the_time( 'Y-m-d' ) . '">' .
+				get_the_time( get_option('date_format') ) . '</span>';
 			// Number of comments
 			if( get_comments_number() > 0 ){
 				$out .= '<div property="interactionStatistic" typeof="InteractionCounter">';

--- a/public/rpr_template_tags.php
+++ b/public/rpr_template_tags.php
@@ -439,12 +439,12 @@ if( !function_exists( 'get_the_rpr_structured_data_header' ) ){
 			}
 			// Metadata like servings, nutrtion, ...
 			if( isset( $recipe['rpr_recipe_servings'][0] ) ){
-				$out .= '"recipeYield": "' . esc_html( $recipe['rpr_recipe_servings'][0] ) . '&nbsp;' . esc_html( $recipe['rpr_recipe_servings_type'][0] ) . '",';
+				$out .= '"recipeYield": "' . esc_html( $recipe['rpr_recipe_servings'][0] ) . ' ' . esc_html( $recipe['rpr_recipe_servings_type'][0] ) . '",';
 			}
-			if( AdminPageFramework::getOption( 'rpr_options', array( 'metadata', 'use_nutritional_data' ), false ) === true &&
+			if( AdminPageFramework::getOption( 'rpr_options', array( 'metadata', 'use_nutritional_data' ), false ) == true &&
 			( $recipe['rpr_recipe_calorific_value'][0] + $recipe['rpr_recipe_fat'][0] +  $recipe['rpr_recipe_protein'][0] +  $recipe['rpr_recipe_carbohydrate'][0] ) >= 0 ) {
 				$out .= '"nutrition": {';
-				$out .= '"@type": "NutritionInformation"';
+				$out .= '"@type": "NutritionInformation",';
 				
 				if( isset( $recipe['rpr_recipe_calorific_value'][0] ) ){
 					$out .= '"calories": "' . esc_html( $recipe['rpr_recipe_calorific_value'][0] ) . '",';
@@ -479,6 +479,7 @@ if( !function_exists( 'get_the_rpr_structured_data_header' ) ){
 				if( isset( $recipe['rpr_recipe_unsaturatedFat'][0] ) ){
 					$out .= '"unsaturatedFatContent": "' . esc_html( $recipe['rpr_recipe_unsaturatedFat'][0] ) . '",';
 				}
+				$out = rtrim($out, ",");
 				$out .= '},';
 			}
 			// Times
@@ -885,7 +886,7 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 			 * Set custom link if available, no link if not
 			 */
 			if( isset( $ingredient['link'] ) ){
-				$out .= '<a href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
+				$out .= '<a Rar href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
 				$closing_tag = '</a>';
 			} else {
 				$closing_tag = ' ';

--- a/public/rpr_template_tags.php
+++ b/public/rpr_template_tags.php
@@ -848,12 +848,12 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 		/**
 		 * Render amount
 		 */
-		$out .= '<span class="recipe-ingredient-quantity">' . esc_html( $ingredient['amount'] ) . '</span>&nbsp;';
+		$out .= '<span class="recipe-ingredient-quantity">' . esc_html( $ingredient['amount'] ) . ' </span>';
 		
 		/**
 		 * Render the unit
 		 */
-		$out .= '<span class="recipe-ingredient-unit">' . esc_html( $ingredient['unit'] ) . '</span>&nbsp;';
+		$out .= '<span class="recipe-ingredient-unit">' . esc_html( $ingredient['unit'] ) . ' </span>';
 	
 		/**
 		 * Render the ingredient link according to the settings
@@ -896,23 +896,25 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 		/**
 		 * Render the ingredient name
 		 */
-		if( isset( $ingredient['amount'] ) && $ingredient['amount'] > 1 ){
-			/**
-			 * Use plural if amount > 1
-			 */
-			if( get_term_meta( $term->term_id, 'plural', true ) != '' ){
-				$out .= '<span name="rpr-ingredient-name" >' . esc_html( get_term_meta( $term->term_id, 'plural', true ) ) . '</span>';
-			} else {
-				$out .= '<span name="rpr-ingredient-name" >' . $term->name . __( 's', 'recipepress-reloaded' ) . '</span>';
-			}
-		} else {
-			/**
-			 * Use singular
-			 */
-			$out .= '<span name="rpr-ingredient-name" >' . $term->name . '</span>';
-		}
+//		if( isset( $ingredient['amount'] ) && $ingredient['amount'] > 1 ){
+//			/**
+//			 * Use plural if amount > 1
+//			 */
+//			if( get_term_meta( $term->term_id, 'plural', true ) != '' ){
+//				$out .= '<span name="rpr-ingredient-name" >' . esc_html( get_term_meta( $term->term_id, 'plural', true ) ) . '</span>';
+//			} else {
+//				$out .= '<span name="rpr-ingredient-name" >' . $term->name . __( 's', 'recipepress-reloaded' ) . '</span>';
+//			}
+//		} else {
+//			/**
+//			 * Use singular
+//			 */
+//			$out .= '<span name="rpr-ingredient-name" >' . $term->name . '</span>';
+//		}
+
+		$out .= '<span name="rpr-ingredient-name" >' . $term->name . '</span>';
 		
-		$out .= $closing_tag;
+		$out .= "";
 	
 		/**
 		 * Render the ingredient note
@@ -926,21 +928,22 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 				/**
 				 * No separator
 				 */
+				$out .= ' ';
 				$closing_tag = '';
 			} elseif (AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'ingredients', 'comment_sep' ), 0 ) == 1 ) {
 				/**
 				 * Brackets
 				 */
-				$out .= __( '(', 'reciperess-reloaded' );
+				$out .= __( ' (', 'reciperess-reloaded' );
 				$closing_tag = __( ')', 'recipepress-reloaded' );
 			} else {
 				/**
 				 * comma
 				 */
-				$out .= __( ',', 'recipepress-reloaded' );
+				$out .= __( ', ', 'recipepress-reloaded' );
 				$closing_tag = '';
 			}
-			$out .= '&nbsp;' .  esc_html( $ingredient['notes'] ) . $closing_tag . '</span>';
+			$out .= esc_html( $ingredient['notes'] ) . $closing_tag . '</span>';
 			
 		}
 		

--- a/public/rpr_template_tags.php
+++ b/public/rpr_template_tags.php
@@ -868,24 +868,24 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 			/**
 			 * Set link to archive
 			 */
-			$out .= '<a Bar href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
+			$out .= '<a href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
 			$closing_tag = '</a>';
 		} elseif( AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'ingredients', 'link_target' ), 2 ) == 2 ){
 			/**
 			 * Set custom link if available, link to archive if not
 			 */
-			if( isset( $ingredient['link'] ) ){
-				$out .= '<a Foo href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
+			if( isset( $ingredient['link'] ) && $ingredient['link'] != '' ){
+				$out .= '<a href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
 				$closing_tag = '</a>';
 			} else {
-				$out .= '<a Baz href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
+				$out .= '<a href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
 			}
 			$closing_tag ='</a>';
 		} else{ 
 			/**
 			 * Set custom link if available, no link if not
 			 */
-			if( isset( $ingredient['link'] ) ){
+			if( isset( $ingredient['link'] ) && $ingredient['link'] != '' ){
 				$out .= '<a Rar href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
 				$closing_tag = '</a>';
 			} else {

--- a/public/rpr_template_tags.php
+++ b/public/rpr_template_tags.php
@@ -862,25 +862,24 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 			/**
 			 * Set no link
 			 */
-			$closing_tag = '&nbsp;';
+			$closing_tag = ' ';
 		} elseif( AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'ingredients', 'link_target' ), 2 ) == 1 ){
 			/**
 			 * Set link to archive
 			 */
-			$out .= '<a href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
-			$closing_tag = '</a>&nbsp;';
+			$out .= '<a Bar href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
+			$closing_tag = '</a>';
 		} elseif( AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'ingredients', 'link_target' ), 2 ) == 2 ){
 			/**
 			 * Set custom link if available, link to archive if not
 			 */
 			if( isset( $ingredient['link'] ) ){
-				$out .= '<a href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
+				$out .= '<a Foo href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
 				$closing_tag = '</a>';
 			} else {
-				$out .= '<a href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
+				$out .= '<a Baz href="' . get_term_link( $term->slug, 'rpr_ingredient' ) . '">';
 			}
-			
-			$closing_tag ='</a>&nbsp;';
+			$closing_tag ='</a>';
 		} else{ 
 			/**
 			 * Set custom link if available, no link if not
@@ -889,10 +888,10 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 				$out .= '<a href="' . esc_url( $ingredient['link'] ) . '" target="_blank" >';
 				$closing_tag = '</a>';
 			} else {
-				$closing_tag = '&nbsp;';
+				$closing_tag = ' ';
 			}
 		}
-		
+
 		/**
 		 * Render the ingredient name
 		 */
@@ -913,8 +912,8 @@ if( !  function_exists( 'get_the_rpr_recipe_ingredients' ) ){
 //		}
 
 		$out .= '<span name="rpr-ingredient-name" >' . $term->name . '</span>';
-		
-		$out .= "";
+
+		$out .= $closing_tag;
 	
 		/**
 		 * Render the ingredient note


### PR DESCRIPTION
The recipe print was was not being added to HTML as the 'esc_attr' function only returns a cleaned string. Switch to using the WP builtin 'sanitize_html_class()' function for sanitizing strings to HTML classnames.