### PR TITLE
fixed 'in_array' PHP error warning

### DIFF
--- a/admin/class-rpr-admin-generalmeta.php
+++ b/admin/class-rpr-admin-generalmeta.php
@@ -139,7 +139,7 @@ class RPR_Admin_GeneralMeta {
                 if( $unit == $selected ) { $outp .= ' selected="selected" '; }
                 $outp .= '>' . $unit . '</option>' . "\n";
             }
-            if( ! in_array( $units, $selected )){
+            if( ! in_array( $selected, $units )){
                 $outp .= '<option value="' . $selected . '"  selected="selected" >' . $selected . '</option>\n';
             }
             return $outp;

--- a/admin/class-rpr-admin-ingredients.php
+++ b/admin/class-rpr-admin-ingredients.php
@@ -77,7 +77,7 @@ class RPR_Admin_Ingredients {
             if( $unit == $selected ) { $outp .= ' selected="selected" '; }
             $outp .= '>' . $unit . '</option>' . "\n";
         }
-        if( ! in_array( $units, $selected )){
+        if( ! in_array( $selected, $units )){
             $outp .= '<option value="' . $selected . '"  selected="selected" >' . $selected . '</option>\n';
         }
         return $outp;


### PR DESCRIPTION
Switched around the 'needle and haystack' arguments for the ````in_array()```` PHP function.