### PR TITLE
allow RPR JS files to load only on RPR admin pages

### DIFF
--- a/admin/class-rpr-admin.php
+++ b/admin/class-rpr-admin.php
@@ -149,21 +149,26 @@ class RPR_Admin {
      *
      * @since    0.8.0
      */
-    public function enqueue_scripts() {
+    public function enqueue_scripts($hook) {
         /**
          * @todo minify the JavaScript! Or at least put all in one file
          */
 		//wp_enqueue_script( 'recipepress-reloaded', plugin_dir_url( __FILE__ ) . 'js/rpr-admin.js', array ( 'jquery' ), $this->version, false );
-        
-        wp_enqueue_script( 'recipepress-reloaded' . '_meta_ing_table', plugin_dir_url( __FILE__ ) . 'js/rpr-admin-ing-meta-table.js', array ( 'jquery' ), $this->version, false );
-        
-        wp_enqueue_script( 'recipepress-reloaded' . '_meta_ing_link', plugin_dir_url( __FILE__ ) . 'js/rpr-admin-ing-meta-link.js', array ( 'jquery' ), $this->version, false );
-        
-        wp_enqueue_script( 'recipepress-reloaded' . '_meta_ins_table', plugin_dir_url( __FILE__ ) . 'js/rpr-admin-ins-meta-table.js', array ( 'jquery' ), $this->version, false );
+        global $post;
+
+        if ( $hook == 'post-new.php' || $hook == 'post.php' ) {
+            if ( 'rpr_recipe' === $post->post_type ) {
+                wp_enqueue_script( 'recipepress-reloaded' . '_meta_ing_table', plugin_dir_url( __FILE__ ) . 'js/rpr-admin-ing-meta-table.js', array ( 'jquery' ), $this->version, false );
+                wp_enqueue_script( 'recipepress-reloaded' . '_meta_ing_link', plugin_dir_url( __FILE__ ) . 'js/rpr-admin-ing-meta-link.js', array ( 'jquery' ), $this->version, false );
+                wp_enqueue_script( 'recipepress-reloaded' . '_meta_ins_table', plugin_dir_url( __FILE__ ) . 'js/rpr-admin-ins-meta-table.js', array ( 'jquery' ), $this->version, false );
+            }
+        }
+
         $translations = array(
             'ins_img_upload_title'  => __( 'Insert instruction image', 'recipepress-reloaded' ),
             'ins_img_upload_text'   => __( 'Insert image', 'recipepress-reloaded' )
         );
+
         wp_localize_script( 'recipepress-reloaded' . '_meta_ins_table', 'ins_trnsl', $translations);
 		
 		if( AdminPageFramework::getOption( 'rpr_options', array( 'metadata', 'use_nutritional_data') , false ) ) {


### PR DESCRIPTION
Fixed ````$(...).sortable is not a function```` JS error on WP admin pages because RPR JS are loaded without the ````jquery-ui-sortable```` library. 