### PR TITLE
Updated print features

### DIFF
--- a/admin/views/rpr-options-page/rpr-options-page-appearance/class-rpr-options-page-appearance-layout.php
+++ b/admin/views/rpr-options-page/rpr-options-page-appearance/class-rpr-options-page-appearance-layout.php
@@ -81,6 +81,13 @@ class RPR_Options_Page_Appearance_Layout {
                 'tip'           => __( 'Best used in combination with a lightbox plugin.', 'recipepress-reloaded' ),
                 'default'       => true
             ),
+            array(
+                'field_id'	=> 'print_button_link',
+                'type'          => 'checkbox',
+                'title'		=> __('Display print button', 'recipepress-reloaded'),
+                'tip'           => __( 'Adds a print link to your recipes. It\'s recommended to use one of the numerous print plugins for wordpress to include a print link to ALL of your posts.', 'recipepress-reloaded' ),
+                'default'       => true
+            ),
             /*array(
                 'field_id'	=> 'images_instruction',
                 'type'          => 'checkbox',

--- a/public/class-rpr-public.php
+++ b/public/class-rpr-public.php
@@ -111,7 +111,8 @@ class RPR_Public {
          * between the defined hooks and the functions defined in this
          * class.
          */
-        wp_enqueue_script( 'recipepress-reloaded', plugin_dir_url( __FILE__ ) . 'js/rpr-public.js', array ( 'jquery' ), $this->version, false );
+        wp_enqueue_script( 'recipepress-reloaded', plugin_dir_url( __FILE__ ) . 'js/rpr-public.js', array ( 'jquery' ), $this->version, true );
+        wp_enqueue_script( 'recipepress-reloaded-print', plugin_dir_url( __FILE__ ) . 'js/rpr-print.js', array ( 'jquery' ), '1.5.1', true );
     }
 
     // Add Widgets

--- a/public/class-rpr-public.php
+++ b/public/class-rpr-public.php
@@ -111,8 +111,7 @@ class RPR_Public {
          * between the defined hooks and the functions defined in this
          * class.
          */
-        wp_enqueue_script( 'recipepress-reloaded', plugin_dir_url( __FILE__ ) . 'js/rpr-public.js', array ( 'jquery' ), $this->version, true );
-        wp_enqueue_script( 'recipepress-reloaded-print', plugin_dir_url( __FILE__ ) . 'js/rpr-print.js', array ( 'jquery' ), '1.5.1', true );
+        wp_enqueue_script( 'recipepress-reloaded', plugin_dir_url( __FILE__ ) . 'js/rpr-public.js', array ( 'jquery' ), $this->version, true );        
     }
 
     // Add Widgets

--- a/public/js/rpr-print.js
+++ b/public/js/rpr-print.js
@@ -1,0 +1,255 @@
+/* @license 
+ * jQuery.print, version 1.5.1
+ *  (c) Sathvik Ponangi, Doers' Guild
+ * Licence: CC-By (http://creativecommons.org/licenses/by/3.0/)
+ *--------------------------------------------------------------------------*/
+(function ($) {
+    "use strict";
+    // A nice closure for our definitions
+    function getjQueryObject(string) {
+        // Make string a vaild jQuery thing
+        var jqObj = $("");
+        try {
+            jqObj = $(string)
+                .clone();
+        } catch (e) {
+            jqObj = $("<span />")
+                .html(string);
+        }
+        return jqObj;
+    }
+
+    function printFrame(frameWindow, content, options) {
+        // Print the selected window/iframe
+        var def = $.Deferred();
+        try {
+            frameWindow = frameWindow.contentWindow || frameWindow.contentDocument || frameWindow;
+            var wdoc = frameWindow.document || frameWindow.contentDocument || frameWindow;
+            if(options.doctype) {
+                wdoc.write(options.doctype);
+            }
+            wdoc.write(content);
+            wdoc.close();
+            var printed = false;
+            var callPrint = function () {
+                if(printed) {
+                    return;
+                }
+                // Fix for IE : Allow it to render the iframe
+                frameWindow.focus();
+                try {
+                    // Fix for IE11 - printng the whole page instead of the iframe content
+                    if (!frameWindow.document.execCommand('print', false, null)) {
+                        // document.execCommand returns false if it failed -http://stackoverflow.com/a/21336448/937891
+                        frameWindow.print();
+                    }
+                    // focus body as it is losing focus in iPad and content not getting printed
+                    $('body').focus();
+                } catch (e) {
+                    frameWindow.print();
+                }
+                frameWindow.close();
+                printed = true;
+                def.resolve();
+            }
+            // Print once the frame window loads - seems to work for the new-window option but unreliable for the iframe
+            $(frameWindow).on("load", callPrint);
+            // Fallback to printing directly if the frame doesn't fire the load event for whatever reason
+            setTimeout(callPrint, options.timeout);
+        } catch (err) {
+            def.reject(err);
+        }
+        return def;
+    }
+
+    function printContentInIFrame(content, options) {
+        var $iframe = $(options.iframe + "");
+        var iframeCount = $iframe.length;
+        if (iframeCount === 0) {
+            // Create a new iFrame if none is given
+            $iframe = $('<iframe height="0" width="0" border="0" wmode="Opaque"/>')
+                .prependTo('body')
+                .css({
+                    "position": "absolute",
+                    "top": -999,
+                    "left": -999
+                });
+        }
+        var frameWindow = $iframe.get(0);
+        return printFrame(frameWindow, content, options)
+            .done(function () {
+                // Success
+                setTimeout(function () {
+                    // Wait for IE
+                    if (iframeCount === 0) {
+                        // Destroy the iframe if created here
+                        $iframe.remove();
+                    }
+                }, 1000);
+            })
+            .fail(function (err) {
+                // Use the pop-up method if iframe fails for some reason
+                console.error("Failed to print from iframe", err);
+                printContentInNewWindow(content, options);
+            })
+            .always(function () {
+                try {
+                    options.deferred.resolve();
+                } catch (err) {
+                    console.warn('Error notifying deferred', err);
+                }
+            });
+    }
+
+    function printContentInNewWindow(content, options) {
+        // Open a new window and print selected content
+        var frameWindow = window.open();
+        return printFrame(frameWindow, content, options)
+            .always(function () {
+                try {
+                    options.deferred.resolve();
+                } catch (err) {
+                    console.warn('Error notifying deferred', err);
+                }
+            });
+    }
+
+    function isNode(o) {
+        /* http://stackoverflow.com/a/384380/937891 */
+        return !!(typeof Node === "object" ? o instanceof Node : o && typeof o === "object" && typeof o.nodeType === "number" && typeof o.nodeName === "string");
+    }
+    $.print = $.fn.print = function () {
+        // Print a given set of elements
+        var options, $this, self = this;
+        // console.log("Printing", this, arguments);
+        if (self instanceof $) {
+            // Get the node if it is a jQuery object
+            self = self.get(0);
+        }
+        if (isNode(self)) {
+            // If `this` is a HTML element, i.e. for
+            // $(selector).print()
+            $this = $(self);
+            if (arguments.length > 0) {
+                options = arguments[0];
+            }
+        } else {
+            if (arguments.length > 0) {
+                // $.print(selector,options)
+                $this = $(arguments[0]);
+                if (isNode($this[0])) {
+                    if (arguments.length > 1) {
+                        options = arguments[1];
+                    }
+                } else {
+                    // $.print(options)
+                    options = arguments[0];
+                    $this = $("html");
+                }
+            } else {
+                // $.print()
+                $this = $("html");
+            }
+        }
+        // Default options
+        var defaults = {
+            globalStyles: true,
+            mediaPrint: false,
+            stylesheet: null,
+            noPrintSelector: ".no-print",
+            iframe: true,
+            append: null,
+            prepend: null,
+            manuallyCopyFormValues: true,
+            deferred: $.Deferred(),
+            timeout: 750,
+            title: null,
+            doctype: '<!doctype html>'
+        };
+        // Merge with user-options
+        options = $.extend({}, defaults, (options || {}));
+        var $styles = $("");
+        if (options.globalStyles) {
+            // Apply the stlyes from the current sheet to the printed page
+            $styles = $("style, link, meta, base, title");
+        } else if (options.mediaPrint) {
+            // Apply the media-print stylesheet
+            $styles = $("link[media=print]");
+        }
+        if (options.stylesheet) {
+            // Add a custom stylesheet if given
+            $styles = $.merge($styles, $('<link rel="stylesheet" href="' + options.stylesheet + '">'));
+        }
+        // Create a copy of the element to print
+        var copy = $this.clone();
+        // Wrap it in a span to get the HTML markup string
+        copy = $("<span/>")
+            .append(copy);
+        // Remove unwanted elements
+        copy.find(options.noPrintSelector)
+            .remove();
+        // Add in the styles
+        copy.append($styles.clone());
+        // Update title
+        if (options.title) {
+            var title = $("title", copy);
+            if (title.length === 0) {
+                title = $("<title />");
+                copy.append(title);                
+            }
+            title.text(options.title);            
+        }
+        // Appedned content
+        copy.append(getjQueryObject(options.append));
+        // Prepended content
+        copy.prepend(getjQueryObject(options.prepend));
+        if (options.manuallyCopyFormValues) {
+            // Manually copy form values into the HTML for printing user-modified input fields
+            // http://stackoverflow.com/a/26707753
+            copy.find("input")
+                .each(function () {
+                    var $field = $(this);
+                    if ($field.is("[type='radio']") || $field.is("[type='checkbox']")) {
+                        if ($field.prop("checked")) {
+                            $field.attr("checked", "checked");
+                        }
+                    } else {
+                        $field.attr("value", $field.val());
+                    }
+                });
+            copy.find("select").each(function () {
+                var $field = $(this);
+                $field.find(":selected").attr("selected", "selected");
+            });
+            copy.find("textarea").each(function () {
+                // Fix for https://github.com/DoersGuild/jQuery.print/issues/18#issuecomment-96451589
+                var $field = $(this);
+                $field.text($field.val());
+            });
+        }
+        // Get the HTML markup string
+        var content = copy.html();
+        // Notify with generated markup & cloned elements - useful for logging, etc
+        try {
+            options.deferred.notify('generated_markup', content, copy);
+        } catch (err) {
+            console.warn('Error notifying deferred', err);
+        }
+        // Destroy the copy
+        copy.remove();
+        if (options.iframe) {
+            // Use an iframe for printing
+            try {
+                printContentInIFrame(content, options);
+            } catch (e) {
+                // Use the pop-up method if iframe fails for some reason
+                console.error("Failed to print from iframe", e.stack, e.message);
+                printContentInNewWindow(content, options);
+            }
+        } else {
+            // Use a new window for printing
+            printContentInNewWindow(content, options);
+        }
+        return this;
+    };
+})(jQuery);

--- a/public/layouts/rpr_2column/functions.php
+++ b/public/layouts/rpr_2column/functions.php
@@ -11,11 +11,23 @@ add_action( 'wp_enqueue_scripts', 'rpr_2column_scripts'  );
 
 function rpr_2column_styles( ){
 	wp_enqueue_style( 'rpr_2column',  plugin_dir_url( __FILE__ ) . '/public.css', array (), '0.0.1', 'all' );
-	wp_enqueue_style( 'rpr_2column_prn',  plugin_dir_url( __FILE__ ) . '/print.css', array (), '0.0.1', 'print' );
+	if( AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) ) ){
+		wp_enqueue_style( 'rpr_2column_prn',  plugin_dir_url( __FILE__ ) . '/print.css', array (), '0.0.1', 'print' );
+	}	
 }
 
 function rpr_2column_scripts( ){
-	wp_enqueue_script( 'jquery-print', plugin_dir_url( __FILE__ ) . '/print.js', array('jquery'), '0.0.1' );
+	$print_data = array(
+		'print_area' => esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_2column', 'printlink_class' ), '.rpr_recipe' )),
+		'no_print_area' => esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_2column', 'no_printlink_class' ), '.no-print' )),
+		'print_css' => plugin_dir_url( __FILE__ ) . 'print.css'
+	);
+
+	if( AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) ) ){
+		wp_enqueue_script( 'rpr-print-js', plugin_dir_url(dirname(__FILE__)) . '../js/rpr-print.js', array ( 'jquery' ), '1.5.1', true );
+		wp_enqueue_script( 'rpr-print-opt', plugin_dir_url( __FILE__ ) . '/print.js', array('jquery'), '0.0.1' );
+		wp_localize_script('rpr-print-opt', 'print_options', $print_data);
+	}
 }
 
 
@@ -26,11 +38,12 @@ if ( !function_exists('get_the_recipe_print_link') ) {
 	// a link to print only the recipe.
 	function get_the_recipe_print_link() {
 		$out = '';
-		if ( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_display' ), false ) == true ){
-			$out .= '<script>';
-			$out .= 'var rpr_printarea="' . esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe' ) ) . '";' ;
-			$out .= '</script>';
-			$out .= '<span class="print-link"></span>';
+		if ( AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) ) ){
+			$out .= '<span class="print-link">';
+			$out .= '<a class="fa fa-print" href="#print"> ';
+			$out .= __('Print', 'recipepress_reloaded');
+			$out .= '</a>';
+			$out .= '</span>';
 		}
 		return $out;
 	}

--- a/public/layouts/rpr_2column/print.js
+++ b/public/layouts/rpr_2column/print.js
@@ -3,7 +3,6 @@
  * @param {type} param
  */
 jQuery(document).ready(function() {
-	console.log('Ping!');
 	jQuery('span.print-link a').click(function() {
 			jQuery(print_options.print_area).print({
 					globalStyles: false,

--- a/public/layouts/rpr_2column/print.js
+++ b/public/layouts/rpr_2column/print.js
@@ -3,91 +3,13 @@
  * @param {type} param
  */
 jQuery(document).ready(function() {
-	 jQuery('span.print-link').prepend('<a class="fa fa-print" href="#print"></a>');
-	 jQuery('span.print-link a').click(function() {
-		 jQuery(rpr_printarea).print();
-	  return false;
-	 });
-	});  
-
-
-// FOUND at http://www.bennadel.com/blog/1591-ask-ben-print-part-of-a-web-page-with-jquery.htm
-
-// Create a jquery plugin that prints the given element.
-jQuery.fn.print = function(){
-// NOTE: We are trimming the jQuery collection down to the
-// first element in the collection.
-if (this.size() > 1){
-this.eq( 0 ).print();
-return;
-} else if (!this.size()){
-return;
-}
- 
-// ASSERT: At this point, we know that the current jQuery
-// collection (as defined by THIS), contains only one
-// printable element.
- 
-// Create a random name for the print frame.
-var strFrameName = ("printer-" + (new Date()).getTime());
- 
-// Create an iFrame with the new name.
-var jFrame = jQuery( "<iframe name='" + strFrameName + "'>" );
- 
-// Hide the frame (sort of) and attach to the body.
-jFrame
-.css( "width", "1px" )
-.css( "height", "1px" )
-.css( "position", "absolute" )
-.css( "left", "-9999px" )
-.appendTo( jQuery( "body:first" ) )
-;
- 
-// Get a FRAMES reference to the new frame.
-var objFrame = window.frames[ strFrameName ];
- 
-// Get a reference to the DOM in the new frame.
-var objDoc = objFrame.document;
- 
-// Grab all the style tags and copy to the new
-// document so that we capture look and feel of
-// the current document.
- 
-// Create a temp document DIV to hold the style tags.
-// This is the only way I could find to get the style
-// tags into IE.
-var jStyleDiv = jQuery( "<div>" ).append(
-jQuery( "style" ).clone()
-);
- 
-// Write the HTML for the document. In this, we will
-// write out the HTML of the current element.
-objDoc.open();
-objDoc.write( "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" );
-objDoc.write( "<html>" );
-objDoc.write( "<body>" );
-objDoc.write( "<head>" );
-objDoc.write( "<title>" );
-objDoc.write( document.title );
-objDoc.write( "</title>" );
-objDoc.write( jStyleDiv.html() );
-objDoc.write( "</head>" );
-objDoc.write( this.html() );
-objDoc.write( "</body>" );
-objDoc.write( "</html>" );
-objDoc.close();
- 
-// Print the document.
-objFrame.focus();
-objFrame.print();
- 
-// Have the frame remove itself in about a minute so that
-// we don't build up too many of these frames.
-setTimeout(
-function(){
-jFrame.remove();
-},
-(60 * 1000)
-);
-}
-
+	console.log('Ping!');
+	jQuery('span.print-link a').click(function() {
+			jQuery(print_options.print_area).print({
+					globalStyles: false,
+					noPrintSelector: print_options.no_print_area,
+					stylesheet: print_options.print_css
+			});
+			return false;
+	});
+});

--- a/public/layouts/rpr_2column/recipe.php
+++ b/public/layouts/rpr_2column/recipe.php
@@ -9,7 +9,7 @@ Description: A basic layoutin two columns. This layout provides all the bits you
 */
 ?>
 
-<div class="<?php esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
+<div class="<?php echo sanitize_html_class( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
 <?php
 /** 
  * Displaying the recipe title is normally done by the theme as post_title().

--- a/public/layouts/rpr_2column/settings.php
+++ b/public/layouts/rpr_2column/settings.php
@@ -18,17 +18,17 @@ $oFactory->addSettingFields(
         'description'   => __( 'Icons not only look nice. They also can save you space. With this setting activated this layout will display <span class="admin_demo""><i class="fa fa-clock-o" title="ready in" ></i> 35min</span> instead of <span class="admin_demo"><span style="text-transform:uppercase; font-weight:bold;">Ready in: </span>35min</span>.' , 'recipepress-reloaded' ),
     ),
     array(
-        'field_id'	=> 'printlink_display',
-        'type'          => 'checkbox',
-        'title'		=> __( 'Display print link', 'recipepress-reloaded' ),
-        'tip'           => __( 'Adds a print link to your recipes. It\'s recommended to use one of the numerous print plugins for wordpress to include a print link to ALL of your posts.', 'recipepress-reloaded' ),
-        'default'       => false
-    ),
-    array(
         'field_id'	=> 'printlink_class',
         'type'          => 'text',
         'title'		=> __( 'Print area class', 'recipepress-reloaded' ),
         'tip'           => __( 'Print links should only print an area of the page, usually a post. This is higly depending on wordpress theme you are using. Add here the class (prefixed by \'.\') or the id (prefixed by \'#\') of the printable area.', 'recipepress-reloaded' ),
         'default'       => '.rpr_recipe'
+    ),
+    array(
+        'field_id'	=> 'no_printlink_class',
+        'type'          => 'text',
+        'title'		=> __( 'Do not print area class', 'recipepress-reloaded' ),
+        'tip'           => __( 'Enter the class or ID of areas or elements that should not be printed. This is higly depending on wordpress theme you are using. Add here the class (prefixed by \'.\') or the id (prefixed by \'#\') of the printable area. Separate multiple entries with commas (\',\').', 'recipepress-reloaded' ),
+        'default'       => '.no-print'
     )
 );

--- a/public/layouts/rpr_default/functions.php
+++ b/public/layouts/rpr_default/functions.php
@@ -12,7 +12,7 @@ add_action( 'wp_enqueue_scripts', 'rpr_default_scripts'  );
 function rpr_default_styles( ){
 	wp_enqueue_style( 'rpr_default',  plugin_dir_url( __FILE__ ) . '/public.css', array (), '0.0.1', 'all' );
 
-	if(AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) )){
+	if( AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) ) ){
 		wp_enqueue_style( 'rpr_default_prn',  plugin_dir_url( __FILE__ ) . '/print.css', array (), '0.0.1', 'print' );
 	}
 }
@@ -24,7 +24,7 @@ function rpr_default_scripts( ){
         'print_css' => plugin_dir_url( __FILE__ ) . 'print.css'
 	);
 
-	if(AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) )){
+	if( AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) ) ){
 		wp_enqueue_script( 'rpr-print-js', plugin_dir_url(dirname(__FILE__)) . '../js/rpr-print.js', array ( 'jquery' ), '1.5.1', true );
 		wp_enqueue_script( 'rpr-print-opt',  plugin_dir_url( __FILE__ ) . 'print.js', array (), '0.0.1', true );
 		wp_localize_script('rpr-print-opt', 'print_options', $print_data);

--- a/public/layouts/rpr_default/functions.php
+++ b/public/layouts/rpr_default/functions.php
@@ -11,11 +11,24 @@ add_action( 'wp_enqueue_scripts', 'rpr_default_scripts'  );
 
 function rpr_default_styles( ){
 	wp_enqueue_style( 'rpr_default',  plugin_dir_url( __FILE__ ) . '/public.css', array (), '0.0.1', 'all' );
-	wp_enqueue_style( 'rpr_default_prn',  plugin_dir_url( __FILE__ ) . '/print.css', array (), '0.0.1', 'print' );
+
+	if(AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) )){
+		wp_enqueue_style( 'rpr_default_prn',  plugin_dir_url( __FILE__ ) . '/print.css', array (), '0.0.1', 'print' );
+	}
 }
 
 function rpr_default_scripts( ){
-	wp_enqueue_script( 'jquery-print', plugin_dir_url( __FILE__ ) . '/print.js', array('jquery'), '0.0.1' );
+	$print_data = array(
+        'print_area' => esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe' )),
+        'no_print_area' => esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'no_printlink_class' ), '.no-print' )),
+        'print_css' => plugin_dir_url( __FILE__ ) . 'print.css'
+	);
+
+	if(AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) )){
+		wp_enqueue_script( 'rpr-print-js', plugin_dir_url(dirname(__FILE__)) . '../js/rpr-print.js', array ( 'jquery' ), '1.5.1', true );
+		wp_enqueue_script( 'rpr-print-opt',  plugin_dir_url( __FILE__ ) . 'print.js', array (), '0.0.1', true );
+		wp_localize_script('rpr-print-opt', 'print_options', $print_data);
+	}	
 }
 
 
@@ -26,11 +39,12 @@ if ( !function_exists('get_the_recipe_print_link') ) {
 	// a link to print only the recipe.
 	function get_the_recipe_print_link() {
 		$out = '';
-		if ( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_display' ), false ) == true ){
-			$out .= '<script>';
-			$out .= 'var rpr_printarea="' . esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe' ) ) . '";' ;
-			$out .= '</script>';
-			$out .= '<span class="print-link"></span>';
+		if ( AdminPageFramework::getOption( 'rpr_options', array( 'layout_general', 'print_button_link' ) ) ){
+			$out .= '<span class="print-link">';
+			$out .= '<a class="fa fa-print" href="#print"> ';
+			$out .= __('Print', 'recipepress_reloaded');
+			$out .= '</a>';
+			$out .= '</span>';
 		}
 		return $out;
 	}

--- a/public/layouts/rpr_default/print.js
+++ b/public/layouts/rpr_default/print.js
@@ -3,9 +3,12 @@
  * @param {type} param
  */
 jQuery(document).ready(function() {
-	jQuery('span.print-link').prepend('<a class="fa fa-print" href="#print"> Print</a>');
 	jQuery('span.print-link a').click(function() {
-		jQuery(rpr_printarea).print();
-	return false;
+			jQuery(print_options.print_area).print({
+					globalStyles: false,
+					noPrintSelector: print_options.no_print_area,
+					stylesheet: print_options.print_css
+			});
+			return false;
 	});
 });

--- a/public/layouts/rpr_default/print.js
+++ b/public/layouts/rpr_default/print.js
@@ -3,91 +3,9 @@
  * @param {type} param
  */
 jQuery(document).ready(function() {
-	 jQuery('span.print-link').prepend('<a class="fa fa-print" href="#print"></a>');
-	 jQuery('span.print-link a').click(function() {
-		 jQuery(rpr_printarea).print();
-	  return false;
-	 });
-	});  
-
-
-// FOUND at http://www.bennadel.com/blog/1591-ask-ben-print-part-of-a-web-page-with-jquery.htm
-
-// Create a jquery plugin that prints the given element.
-jQuery.fn.print = function(){
-// NOTE: We are trimming the jQuery collection down to the
-// first element in the collection.
-if (this.size() > 1){
-this.eq( 0 ).print();
-return;
-} else if (!this.size()){
-return;
-}
- 
-// ASSERT: At this point, we know that the current jQuery
-// collection (as defined by THIS), contains only one
-// printable element.
- 
-// Create a random name for the print frame.
-var strFrameName = ("printer-" + (new Date()).getTime());
- 
-// Create an iFrame with the new name.
-var jFrame = jQuery( "<iframe name='" + strFrameName + "'>" );
- 
-// Hide the frame (sort of) and attach to the body.
-jFrame
-.css( "width", "1px" )
-.css( "height", "1px" )
-.css( "position", "absolute" )
-.css( "left", "-9999px" )
-.appendTo( jQuery( "body:first" ) )
-;
- 
-// Get a FRAMES reference to the new frame.
-var objFrame = window.frames[ strFrameName ];
- 
-// Get a reference to the DOM in the new frame.
-var objDoc = objFrame.document;
- 
-// Grab all the style tags and copy to the new
-// document so that we capture look and feel of
-// the current document.
- 
-// Create a temp document DIV to hold the style tags.
-// This is the only way I could find to get the style
-// tags into IE.
-var jStyleDiv = jQuery( "<div>" ).append(
-jQuery( "style" ).clone()
-);
- 
-// Write the HTML for the document. In this, we will
-// write out the HTML of the current element.
-objDoc.open();
-objDoc.write( "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" );
-objDoc.write( "<html>" );
-objDoc.write( "<body>" );
-objDoc.write( "<head>" );
-objDoc.write( "<title>" );
-objDoc.write( document.title );
-objDoc.write( "</title>" );
-objDoc.write( jStyleDiv.html() );
-objDoc.write( "</head>" );
-objDoc.write( this.html() );
-objDoc.write( "</body>" );
-objDoc.write( "</html>" );
-objDoc.close();
- 
-// Print the document.
-objFrame.focus();
-objFrame.print();
- 
-// Have the frame remove itself in about a minute so that
-// we don't build up too many of these frames.
-setTimeout(
-function(){
-jFrame.remove();
-},
-(60 * 1000)
-);
-}
-
+	jQuery('span.print-link').prepend('<a class="fa fa-print" href="#print"> Print</a>');
+	jQuery('span.print-link a').click(function() {
+		jQuery(rpr_printarea).print();
+	return false;
+	});
+});

--- a/public/layouts/rpr_default/recipe.php
+++ b/public/layouts/rpr_default/recipe.php
@@ -8,7 +8,7 @@ Version: 0.2
 Description: The default layout. Despite being default this layout provides all the bits you need to display proper recipes. Structured meta data for search engine come standard. </br> Use the options below to finetune the look and feel of your recipes.
 */
 ?>
-<div class="<?php esc_attr( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
+<div class="<?php echo sanitize_html_class( AdminPageFramework::getOption( 'rpr_options', array( 'layout', 'rpr_default', 'printlink_class' ), '.rpr_recipe') ); ?>">
 <?php
 /** 
  * Displaying the recipe title is normally done by the theme as post_title().

--- a/public/layouts/rpr_default/settings.php
+++ b/public/layouts/rpr_default/settings.php
@@ -12,17 +12,17 @@ $oFactory->addSettingFields(
         'description'   => __( 'Icons not only look nice. They also can save you space. With this setting activated this layout will display <span class="admin_demo""><i class="fa fa-clock-o" title="ready in" ></i> 35min</span> instead of <span class="admin_demo"><span style="text-transform:uppercase; font-weight:bold;">Ready in: </span>35min</span>.' , 'recipepress-reloaded' ),
     ),
     array(
-        'field_id'	=> 'printlink_display',
-        'type'          => 'checkbox',
-        'title'		=> __( 'Display print link', 'recipepress-reloaded' ),
-        'tip'           => __( 'Adds a print link to your recipes. It\'s recommended to use one of the numerous print plugins for wordpress to include a print link to ALL of your posts.', 'recipepress-reloaded' ),
-        'default'       => false
-    ),
-    array(
         'field_id'	=> 'printlink_class',
         'type'          => 'text',
         'title'		=> __( 'Print area class', 'recipepress-reloaded' ),
         'tip'           => __( 'Print links should only print an area of the page, usually a post. This is higly depending on wordpress theme you are using. Add here the class (prefixed by \'.\') or the id (prefixed by \'#\') of the printable area.', 'recipepress-reloaded' ),
         'default'       => '.rpr_recipe'
+    ),
+    array(
+        'field_id'	=> 'no_printlink_class',
+        'type'          => 'text',
+        'title'		=> __( 'Do not print area class', 'recipepress-reloaded' ),
+        'tip'           => __( 'Enter the class or ID of areas or elements that should not be printed. This is higly depending on wordpress theme you are using. Add here the class (prefixed by \'.\') or the id (prefixed by \'#\') of the printable area. Separate multiple entries with commas (\',\').', 'recipepress-reloaded' ),
+        'default'       => '.no-print'
     )
 );


### PR DESCRIPTION
- The plugin now uses the jQuery.print, v1.5.1. Which is up-to-date and being actively supported.
- The "Display print button" checkbox has been moved up the "Layout" section.
- Both recipe templates now have the options for a "Print area class" and "Do not print area class" for users to customize sections that are printed or not printed.
- No longer user JavaScript to display print button.
- Print JS and CSS files are only loaded if the "Display print button" option is checked.
- Uses "wp_localize_script" to avoid displaying variables in JS script tags