### PR TITLE
Fixed the display of WP core taxonomies

### DIFF
--- a/public/class-rpr-recipeposttype.php
+++ b/public/class-rpr-recipeposttype.php
@@ -58,10 +58,10 @@ class RPR_RecipePostType extends AdminPageFramework_PostType{
          * Check which of wp core's taxonomies to use;
          */
         $taxonomies = array();
-        if( AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'categories', 'use') , false ) ){
+        if( AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'category', 'use' ) , false ) ){
             array_push($taxonomies, 'category' );
         }
-        if( AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'tags', 'use') , false ) ){
+        if( AdminPageFramework::getOption( 'rpr_options', array( 'tax_builtin', 'post_tag', 'use' ) , false ) ){
             array_push($taxonomies, 'post_tag' );
         }
         


### PR DESCRIPTION
The default WP taxonomies where not showing up on the recipe editor screen when options were enabled.